### PR TITLE
12 OpenAPI Swagger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
                 "@nestjs/jwt": "^10.2.0",
                 "@nestjs/passport": "^10.0.3",
                 "@nestjs/platform-express": "^10.0.0",
+                "@nestjs/swagger": "^7.4.0",
                 "@nestjs/typeorm": "^10.0.2",
                 "@types/passport-jwt": "^4.0.1",
                 "argon2": "^0.31.2",
@@ -1773,6 +1774,12 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/@microsoft/tsdoc": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.0.tgz",
+            "integrity": "sha512-HZpPoABogPvjeJOdzCOSJsXeL/SMCBgBZMVC3X3d7YYp2gf31MfxhUoYUNwf1ERPJOnQc0wkFn9trqI6ZEdZuA==",
+            "license": "MIT"
+        },
         "node_modules/@nestjs/cli": {
             "version": "10.3.2",
             "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-10.3.2.tgz",
@@ -1993,6 +2000,26 @@
                 "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0"
             }
         },
+        "node_modules/@nestjs/mapped-types": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.0.5.tgz",
+            "integrity": "sha512-bSJv4pd6EY99NX9CjBIyn4TVDoSit82DUZlL4I3bqNfy5Gt+gXTa86i3I/i0iIV9P4hntcGM5GyO+FhZAhxtyg==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+                "class-transformer": "^0.4.0 || ^0.5.0",
+                "class-validator": "^0.13.0 || ^0.14.0",
+                "reflect-metadata": "^0.1.12 || ^0.2.0"
+            },
+            "peerDependenciesMeta": {
+                "class-transformer": {
+                    "optional": true
+                },
+                "class-validator": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@nestjs/passport": {
             "version": "10.0.3",
             "resolved": "https://registry.npmjs.org/@nestjs/passport/-/passport-10.0.3.tgz",
@@ -2043,6 +2070,39 @@
             "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
             "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
             "dev": true
+        },
+        "node_modules/@nestjs/swagger": {
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-7.4.0.tgz",
+            "integrity": "sha512-dCiwKkRxcR7dZs5jtrGspBAe/nqJd1AYzOBTzw9iCdbq3BGrLpwokelk6lFZPe4twpTsPQqzNKBwKzVbI6AR/g==",
+            "license": "MIT",
+            "dependencies": {
+                "@microsoft/tsdoc": "^0.15.0",
+                "@nestjs/mapped-types": "2.0.5",
+                "js-yaml": "4.1.0",
+                "lodash": "4.17.21",
+                "path-to-regexp": "3.2.0",
+                "swagger-ui-dist": "5.17.14"
+            },
+            "peerDependencies": {
+                "@fastify/static": "^6.0.0 || ^7.0.0",
+                "@nestjs/common": "^9.0.0 || ^10.0.0",
+                "@nestjs/core": "^9.0.0 || ^10.0.0",
+                "class-transformer": "*",
+                "class-validator": "*",
+                "reflect-metadata": "^0.1.12 || ^0.2.0"
+            },
+            "peerDependenciesMeta": {
+                "@fastify/static": {
+                    "optional": true
+                },
+                "class-transformer": {
+                    "optional": true
+                },
+                "class-validator": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/@nestjs/testing": {
             "version": "10.3.3",
@@ -3129,8 +3189,7 @@
         "node_modules/argparse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         },
         "node_modules/array-flatten": {
             "version": "1.1.1",
@@ -6762,7 +6821,6 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
             "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-            "dev": true,
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -8922,6 +8980,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/swagger-ui-dist": {
+            "version": "5.17.14",
+            "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.17.14.tgz",
+            "integrity": "sha512-CVbSfaLpstV65OnSjbXfVd6Sta3q3F7Cj/yYuvHMp1P90LztOLs6PfUnKEVAeiIVQt9u2SaPwv0LiH/OyMjHRw==",
+            "license": "Apache-2.0"
         },
         "node_modules/symbol-observable": {
             "version": "4.0.0",
@@ -11312,6 +11376,11 @@
                 }
             }
         },
+        "@microsoft/tsdoc": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.0.tgz",
+            "integrity": "sha512-HZpPoABogPvjeJOdzCOSJsXeL/SMCBgBZMVC3X3d7YYp2gf31MfxhUoYUNwf1ERPJOnQc0wkFn9trqI6ZEdZuA=="
+        },
         "@nestjs/cli": {
             "version": "10.3.2",
             "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-10.3.2.tgz",
@@ -11442,6 +11511,12 @@
                 "jsonwebtoken": "9.0.2"
             }
         },
+        "@nestjs/mapped-types": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.0.5.tgz",
+            "integrity": "sha512-bSJv4pd6EY99NX9CjBIyn4TVDoSit82DUZlL4I3bqNfy5Gt+gXTa86i3I/i0iIV9P4hntcGM5GyO+FhZAhxtyg==",
+            "requires": {}
+        },
         "@nestjs/passport": {
             "version": "10.0.3",
             "resolved": "https://registry.npmjs.org/@nestjs/passport/-/passport-10.0.3.tgz",
@@ -11479,6 +11554,19 @@
                     "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
                     "dev": true
                 }
+            }
+        },
+        "@nestjs/swagger": {
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-7.4.0.tgz",
+            "integrity": "sha512-dCiwKkRxcR7dZs5jtrGspBAe/nqJd1AYzOBTzw9iCdbq3BGrLpwokelk6lFZPe4twpTsPQqzNKBwKzVbI6AR/g==",
+            "requires": {
+                "@microsoft/tsdoc": "^0.15.0",
+                "@nestjs/mapped-types": "2.0.5",
+                "js-yaml": "4.1.0",
+                "lodash": "4.17.21",
+                "path-to-regexp": "3.2.0",
+                "swagger-ui-dist": "5.17.14"
             }
         },
         "@nestjs/testing": {
@@ -12353,8 +12441,7 @@
         "argparse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         },
         "array-flatten": {
             "version": "1.1.1",
@@ -15071,7 +15158,6 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
             "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-            "dev": true,
             "requires": {
                 "argparse": "^2.0.1"
             }
@@ -16691,6 +16777,11 @@
             "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
             "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
             "dev": true
+        },
+        "swagger-ui-dist": {
+            "version": "5.17.14",
+            "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.17.14.tgz",
+            "integrity": "sha512-CVbSfaLpstV65OnSjbXfVd6Sta3q3F7Cj/yYuvHMp1P90LztOLs6PfUnKEVAeiIVQt9u2SaPwv0LiH/OyMjHRw=="
         },
         "symbol-observable": {
             "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "@nestjs/jwt": "^10.2.0",
         "@nestjs/passport": "^10.0.3",
         "@nestjs/platform-express": "^10.0.0",
+        "@nestjs/swagger": "^7.4.0",
         "@nestjs/typeorm": "^10.0.2",
         "@types/passport-jwt": "^4.0.1",
         "argon2": "^0.31.2",

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,16 +1,12 @@
 import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { AuthDTO, JwtTokenDTO, RegisterDTO } from './dto';
+import { ApiTags } from '@nestjs/swagger';
 import {
-    ApiBadRequestResponse,
-    ApiBody,
-    ApiConflictResponse,
-    ApiForbiddenResponse,
-    ApiNotFoundResponse,
-    ApiOkResponse,
-    ApiTags,
-    ApiUnauthorizedResponse,
-} from '@nestjs/swagger';
+    GoogleLoginApi,
+    LoginApi,
+    RegisterApi,
+} from '../decorators/OpenAPI/auth.decorators';
 
 @ApiTags('Auth')
 @Controller('auth')
@@ -18,34 +14,21 @@ export class AuthController {
     constructor(private readonly authService: AuthService) {}
 
     @Post('register')
-    @ApiOkResponse({ type: JwtTokenDTO })
-    @ApiBadRequestResponse({ description: 'Invalid body' })
-    @ApiConflictResponse({ description: 'Email already used' })
-    @ApiBody({ type: RegisterDTO })
+    @RegisterApi()
     register(@Body() registerDto: RegisterDTO): Promise<JwtTokenDTO> {
         return this.authService.register(registerDto);
     }
 
     @HttpCode(HttpStatus.OK)
     @Post('login')
-    @ApiOkResponse({ type: JwtTokenDTO })
-    @ApiBadRequestResponse({ description: 'Invalid body' })
-    @ApiUnauthorizedResponse({ description: 'Incorrect password' })
-    @ApiForbiddenResponse({
-        description:
-            'Forbidden login method (user should login with Google Account)',
-    })
-    @ApiNotFoundResponse({ description: 'User not found' })
-    @ApiBody({ type: AuthDTO })
+    @LoginApi()
     login(@Body() authDto: AuthDTO): Promise<JwtTokenDTO> {
         return this.authService.getAuthByUser(authDto);
     }
 
     @HttpCode(HttpStatus.OK)
     @Post('google/login')
-    @ApiOkResponse({ type: JwtTokenDTO })
-    @ApiForbiddenResponse()
-    @ApiConflictResponse({ description: 'Email already used' })
+    @GoogleLoginApi()
     async googleLogin(
         @Body('gToken') googleToken: string,
     ): Promise<JwtTokenDTO> {

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,24 +1,51 @@
 import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { AuthDTO, JwtTokenDTO, RegisterDTO } from './dto';
+import {
+    ApiBadRequestResponse,
+    ApiBody,
+    ApiConflictResponse,
+    ApiForbiddenResponse,
+    ApiNotFoundResponse,
+    ApiOkResponse,
+    ApiTags,
+    ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
 
+@ApiTags('Auth')
 @Controller('auth')
 export class AuthController {
     constructor(private readonly authService: AuthService) {}
 
     @Post('register')
+    @ApiOkResponse({ type: JwtTokenDTO })
+    @ApiBadRequestResponse({ description: 'Invalid body' })
+    @ApiConflictResponse({ description: 'Email already used' })
+    @ApiBody({ type: RegisterDTO })
     register(@Body() registerDto: RegisterDTO): Promise<JwtTokenDTO> {
         return this.authService.register(registerDto);
     }
 
     @HttpCode(HttpStatus.OK)
     @Post('login')
+    @ApiOkResponse({ type: JwtTokenDTO })
+    @ApiBadRequestResponse({ description: 'Invalid body' })
+    @ApiUnauthorizedResponse({ description: 'Incorrect password' })
+    @ApiForbiddenResponse({
+        description:
+            'Forbidden login method (user should login with Google Account)',
+    })
+    @ApiNotFoundResponse({ description: 'User not found' })
+    @ApiBody({ type: AuthDTO })
     login(@Body() authDto: AuthDTO): Promise<JwtTokenDTO> {
         return this.authService.getAuthByUser(authDto);
     }
 
     @HttpCode(HttpStatus.OK)
     @Post('google/login')
+    @ApiOkResponse({ type: JwtTokenDTO })
+    @ApiForbiddenResponse()
+    @ApiConflictResponse({ description: 'Email already used' })
     async googleLogin(
         @Body('gToken') googleToken: string,
     ): Promise<JwtTokenDTO> {

--- a/src/auth/dto/Auth.dto.ts
+++ b/src/auth/dto/Auth.dto.ts
@@ -1,11 +1,14 @@
 import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class AuthDTO {
     @IsEmail()
     @IsNotEmpty()
+    @ApiProperty()
     email: string;
 
     @IsString()
     @IsNotEmpty()
+    @ApiProperty()
     password: string;
 }

--- a/src/auth/dto/JwtToken.dto.ts
+++ b/src/auth/dto/JwtToken.dto.ts
@@ -1,3 +1,6 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 export class JwtTokenDTO {
+    @ApiProperty()
     accessToken: string;
 }

--- a/src/auth/dto/Register.dto.ts
+++ b/src/auth/dto/Register.dto.ts
@@ -1,15 +1,19 @@
 import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class RegisterDTO {
     @IsString()
     @IsNotEmpty()
+    @ApiProperty()
     username: string;
 
     @IsEmail()
     @IsNotEmpty()
+    @ApiProperty()
     email: string;
 
     @IsString()
     @IsNotEmpty()
+    @ApiProperty()
     password: string;
 }

--- a/src/decorators/OpenAPI/auth.decorators.ts
+++ b/src/decorators/OpenAPI/auth.decorators.ts
@@ -1,0 +1,42 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+    ApiBadRequestResponse,
+    ApiBody,
+    ApiConflictResponse,
+    ApiForbiddenResponse,
+    ApiNotFoundResponse,
+    ApiOkResponse,
+    ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import { AuthDTO, JwtTokenDTO, RegisterDTO } from '../../auth/dto';
+
+export function RegisterApi() {
+    return applyDecorators(
+        ApiOkResponse({ type: JwtTokenDTO }),
+        ApiBadRequestResponse({ description: 'Invalid body' }),
+        ApiConflictResponse({ description: 'Email already used' }),
+        ApiBody({ type: RegisterDTO }),
+    );
+}
+
+export function LoginApi() {
+    return applyDecorators(
+        ApiOkResponse({ type: JwtTokenDTO }),
+        ApiBadRequestResponse({ description: 'Invalid body' }),
+        ApiUnauthorizedResponse({ description: 'Incorrect password' }),
+        ApiForbiddenResponse({
+            description:
+                'Forbidden login method (user should login with Google Account)',
+        }),
+        ApiNotFoundResponse({ description: 'User not found' }),
+        ApiBody({ type: AuthDTO }),
+    );
+}
+
+export function GoogleLoginApi() {
+    return applyDecorators(
+        ApiOkResponse({ type: JwtTokenDTO }),
+        ApiForbiddenResponse(),
+        ApiConflictResponse({ description: 'Email already used' }),
+    );
+}

--- a/src/decorators/OpenAPI/event.decorators.ts
+++ b/src/decorators/OpenAPI/event.decorators.ts
@@ -1,0 +1,40 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+    ApiBadRequestResponse,
+    ApiBody,
+    ApiNoContentResponse,
+    ApiNotFoundResponse,
+    ApiOkResponse,
+} from '@nestjs/swagger';
+import { EditEventDTO, ReturnEventDTO } from '../../resource/event/dto';
+
+export function GetUserEventsApi() {
+    return applyDecorators(ApiOkResponse({ type: [ReturnEventDTO] }));
+}
+
+export function GetEventByIdApi() {
+    return applyDecorators(
+        ApiOkResponse({ type: ReturnEventDTO }),
+        ApiNotFoundResponse({ description: 'Event not found' }),
+    );
+}
+
+export function CreateEventByCurrentUserApi() {
+    return applyDecorators(
+        ApiOkResponse({ type: ReturnEventDTO }),
+        ApiNotFoundResponse({ description: 'Event not found' }),
+    );
+}
+
+export function EditEventApi() {
+    return applyDecorators(
+        ApiOkResponse({ type: ReturnEventDTO }),
+        ApiBadRequestResponse({ description: 'Invalid body' }),
+        ApiNotFoundResponse({ description: "Event doesn't exist" }),
+        ApiBody({ type: EditEventDTO }),
+    );
+}
+
+export function DeleteEventApi() {
+    return applyDecorators(ApiNoContentResponse());
+}

--- a/src/decorators/OpenAPI/notes.decorators.ts
+++ b/src/decorators/OpenAPI/notes.decorators.ts
@@ -1,0 +1,30 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+    ApiBadRequestResponse,
+    ApiBody,
+    ApiCreatedResponse,
+    ApiNotFoundResponse,
+    ApiOkResponse,
+} from '@nestjs/swagger';
+import { editNoteDTO, NoteDTO } from '../../resource/notes/dto';
+
+export function FetchUserNotesApi() {
+    return applyDecorators(ApiOkResponse({ type: [NoteDTO] }));
+}
+
+export function AddNoteApi() {
+    return applyDecorators(
+        ApiCreatedResponse({ type: NoteDTO }),
+        ApiBadRequestResponse({ description: 'Invalid body' }),
+        ApiNotFoundResponse({ description: 'User not found' }),
+        ApiBody({ type: NoteDTO }),
+    );
+}
+
+export function EditNoteByIdApi() {
+    return applyDecorators(
+        ApiOkResponse(),
+        ApiBadRequestResponse({ description: 'Invalid body' }),
+        ApiBody({ type: editNoteDTO }),
+    );
+}

--- a/src/decorators/OpenAPI/search.decorators.ts
+++ b/src/decorators/OpenAPI/search.decorators.ts
@@ -1,0 +1,7 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOkResponse } from '@nestjs/swagger';
+import { SearchResultDto } from '../../resource/search/dto';
+
+export function SearchApi() {
+    return applyDecorators(ApiOkResponse({ type: SearchResultDto }));
+}

--- a/src/decorators/OpenAPI/task.decorators.ts
+++ b/src/decorators/OpenAPI/task.decorators.ts
@@ -1,0 +1,51 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+    ApiBadRequestResponse,
+    ApiBody,
+    ApiCreatedResponse,
+    ApiNoContentResponse,
+    ApiNotFoundResponse,
+    ApiOkResponse,
+} from '@nestjs/swagger';
+import {
+    CreateTaskDTO,
+    EditTaskDTO,
+    ReturnTaskDTO,
+} from '../../resource/task/dto';
+
+export function GetAllUserTasksApi() {
+    return applyDecorators(ApiOkResponse({ type: [ReturnTaskDTO] }));
+}
+
+export function GetUserTaskApi() {
+    return applyDecorators(
+        ApiOkResponse({ type: ReturnTaskDTO }),
+        ApiNotFoundResponse({ description: 'Task not found' }),
+    );
+}
+
+export function AddTaskApi() {
+    return applyDecorators(
+        ApiCreatedResponse({ type: ReturnTaskDTO }),
+        ApiBadRequestResponse({ description: 'Invalid body' }),
+        ApiBody({ type: CreateTaskDTO }),
+    );
+}
+
+export function EditTaskApi() {
+    return applyDecorators(
+        ApiOkResponse({ type: ReturnTaskDTO }),
+        ApiBadRequestResponse({
+            description: 'Invalid body / ID is not valid in URL and body',
+        }),
+        ApiNotFoundResponse({ description: 'Task not found' }),
+        ApiBody({ type: EditTaskDTO }),
+    );
+}
+
+export function DeleteTaskApi() {
+    return applyDecorators(
+        ApiNoContentResponse(),
+        ApiNotFoundResponse({ description: 'Task not found' }),
+    );
+}

--- a/src/decorators/OpenAPI/user.decorators.ts
+++ b/src/decorators/OpenAPI/user.decorators.ts
@@ -1,0 +1,28 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+    ApiBadRequestResponse,
+    ApiBody,
+    ApiNotFoundResponse,
+    ApiOkResponse,
+} from '@nestjs/swagger';
+import { EditUserDTO, ReturnUserDTO } from '../../resource/user/dto';
+
+export function GetMeApi() {
+    return applyDecorators(ApiOkResponse({ type: ReturnUserDTO }));
+}
+
+export function EditMeApi() {
+    return applyDecorators(
+        ApiOkResponse({ type: ReturnUserDTO }),
+        ApiBadRequestResponse({ description: 'Invalid body' }),
+        ApiNotFoundResponse({ description: 'User not found' }),
+        ApiBody({ type: EditUserDTO }),
+    );
+}
+
+export function GetUserByIdApi() {
+    return applyDecorators(
+        ApiOkResponse({ type: ReturnUserDTO }),
+        ApiNotFoundResponse({ description: 'User not found' }),
+    );
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,14 +13,14 @@ async function bootstrap() {
         }),
     );
 
-    const apiConfig = new DocumentBuilder()
+    const openApiConfig = new DocumentBuilder()
         .setTitle('DoDo API')
         .setDescription('DoDo API Documentation')
         .setVersion('1.0')
         .addBearerAuth()
         .build();
-    const apiDocument = SwaggerModule.createDocument(app, apiConfig);
-    SwaggerModule.setup('swagger', app, apiDocument);
+    const openApiDocument = SwaggerModule.createDocument(app, openApiConfig);
+    SwaggerModule.setup('swagger', app, openApiDocument);
 
     await app.listen(process.env.PORT || 5000, () => {
         console.log(

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
 async function bootstrap() {
     const app = await NestFactory.create(AppModule);
@@ -11,6 +12,21 @@ async function bootstrap() {
             whitelist: true,
         }),
     );
+
+    const apiConfig = new DocumentBuilder()
+        .setTitle('DoDo API')
+        .setDescription('DoDo API Documentation')
+        .setVersion('1.0')
+        // .addTag('Auth')
+        // .addTag('Events')
+        // .addTag('Notes')
+        // .addTag('Search')
+        // .addTag('Tasks')
+        // .addTag('Users')
+        .build();
+    const apiDocument = SwaggerModule.createDocument(app, apiConfig);
+    SwaggerModule.setup('swagger', app, apiDocument);
+
     await app.listen(process.env.PORT || 5000, () => {
         console.log(
             `Application is running on port: ${process.env.PORT || 5000}`,

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,12 +17,7 @@ async function bootstrap() {
         .setTitle('DoDo API')
         .setDescription('DoDo API Documentation')
         .setVersion('1.0')
-        // .addTag('Auth')
-        // .addTag('Events')
-        // .addTag('Notes')
-        // .addTag('Search')
-        // .addTag('Tasks')
-        // .addTag('Users')
+        .addBearerAuth()
         .build();
     const apiDocument = SwaggerModule.createDocument(app, apiConfig);
     SwaggerModule.setup('swagger', app, apiDocument);

--- a/src/resource/event/dto/CreateEvent.dto.ts
+++ b/src/resource/event/dto/CreateEvent.dto.ts
@@ -5,25 +5,31 @@ import {
     IsOptional,
     IsString,
 } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateEventDTO {
     @IsString()
     @IsNotEmpty()
+    @ApiProperty()
     name: string;
 
     @IsString()
     @IsOptional()
+    @ApiProperty({ required: false })
     description?: string;
 
     @IsDateString()
     @IsNotEmpty()
+    @ApiProperty()
     startDate: Date;
 
     @IsDateString()
     @IsOptional()
+    @ApiProperty({ required: false })
     endDate?: Date;
 
     @IsBoolean()
     @IsNotEmpty()
+    @ApiProperty()
     isFullDay: boolean;
 }

--- a/src/resource/event/dto/EditEvent.dto.ts
+++ b/src/resource/event/dto/EditEvent.dto.ts
@@ -1,23 +1,29 @@
 import { IsBoolean, IsDateString, IsOptional, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class EditEventDTO {
     @IsString()
     @IsOptional()
+    @ApiProperty({ required: false })
     name?: string;
 
     @IsString()
     @IsOptional()
+    @ApiProperty({ required: false })
     description?: string;
 
     @IsDateString()
     @IsOptional()
+    @ApiProperty({ required: false })
     startDate?: Date;
 
     @IsDateString()
     @IsOptional()
+    @ApiProperty({ required: false })
     endDate?: Date;
 
     @IsBoolean()
     @IsOptional()
+    @ApiProperty({ required: false })
     isFullDay?: boolean;
 }

--- a/src/resource/event/dto/ReturnEvent.dto.ts
+++ b/src/resource/event/dto/ReturnEvent.dto.ts
@@ -1,9 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 export class ReturnEventDTO {
+    @ApiProperty()
     id: number;
+    @ApiProperty()
     name: string;
+    @ApiProperty()
     description: string;
+    @ApiProperty()
     startDate: Date;
+    @ApiProperty()
     endDate: Date;
+    @ApiProperty()
     isFullDay: boolean;
+    @ApiProperty()
     createdById: number;
 }

--- a/src/resource/event/event.controller.ts
+++ b/src/resource/event/event.controller.ts
@@ -15,16 +15,14 @@ import { EventService } from 'src/resource/event/event.service';
 import { GetUser } from 'src/decorators';
 import { CreateEventDTO, ReturnEventDTO } from 'src/resource/event/dto';
 import { EditEventDTO } from 'src/resource/event/dto/EditEvent.dto';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import {
-    ApiBadRequestResponse,
-    ApiBearerAuth,
-    ApiBody,
-    ApiCreatedResponse,
-    ApiNoContentResponse,
-    ApiNotFoundResponse,
-    ApiOkResponse,
-    ApiTags,
-} from '@nestjs/swagger';
+    CreateEventByCurrentUserApi,
+    DeleteEventApi,
+    EditEventApi,
+    GetEventByIdApi,
+    GetUserEventsApi,
+} from '../../decorators/OpenAPI/event.decorators';
 
 @UseGuards(JwtGuard)
 @ApiTags('Events')
@@ -34,22 +32,19 @@ export class EventController {
     constructor(private eventService: EventService) {}
 
     @Get()
-    @ApiOkResponse({ type: [ReturnEventDTO] })
+    @GetUserEventsApi()
     getUserEvents(@GetUser('id') userId: number): Promise<ReturnEventDTO[]> {
         return this.eventService.getEventsByUserId(userId);
     }
 
     @Get(':id')
-    @ApiOkResponse({ type: ReturnEventDTO })
-    @ApiNotFoundResponse({ description: 'Event not found' })
+    @GetEventByIdApi()
     getEventById(@Param('id') eventId: number): Promise<ReturnEventDTO> {
         return this.eventService.getEventById(eventId);
     }
 
     @Post()
-    @ApiCreatedResponse({ type: ReturnEventDTO })
-    @ApiBadRequestResponse({ description: 'Invalid body' })
-    @ApiBody({ type: CreateEventDTO })
+    @CreateEventByCurrentUserApi()
     createEventByCurrentUser(
         @GetUser('id') userId: number,
         @Body() eventDto: CreateEventDTO,
@@ -58,10 +53,7 @@ export class EventController {
     }
 
     @Patch(':id')
-    @ApiOkResponse({ type: ReturnEventDTO })
-    @ApiBadRequestResponse({ description: 'Invalid body' })
-    @ApiNotFoundResponse({ description: "Event doesn't exist" })
-    @ApiBody({ type: EditEventDTO })
+    @EditEventApi()
     editEvent(
         @Param('id') eventId: number,
         @Body() editEventDto: EditEventDTO,
@@ -71,7 +63,7 @@ export class EventController {
 
     @HttpCode(HttpStatus.NO_CONTENT)
     @Delete(':id')
-    @ApiNoContentResponse()
+    @DeleteEventApi()
     deleteEvent(@Param('id') eventId: number): Promise<void> {
         return this.eventService.removeEventById(eventId);
     }

--- a/src/resource/event/event.controller.ts
+++ b/src/resource/event/event.controller.ts
@@ -17,6 +17,7 @@ import { CreateEventDTO, ReturnEventDTO } from 'src/resource/event/dto';
 import { EditEventDTO } from 'src/resource/event/dto/EditEvent.dto';
 import {
     ApiBadRequestResponse,
+    ApiBearerAuth,
     ApiBody,
     ApiCreatedResponse,
     ApiNoContentResponse,
@@ -28,6 +29,7 @@ import {
 @UseGuards(JwtGuard)
 @ApiTags('Events')
 @Controller('events')
+@ApiBearerAuth()
 export class EventController {
     constructor(private eventService: EventService) {}
 
@@ -68,8 +70,8 @@ export class EventController {
     }
 
     @HttpCode(HttpStatus.NO_CONTENT)
-    @ApiNoContentResponse()
     @Delete(':id')
+    @ApiNoContentResponse()
     deleteEvent(@Param('id') eventId: number): Promise<void> {
         return this.eventService.removeEventById(eventId);
     }

--- a/src/resource/event/event.controller.ts
+++ b/src/resource/event/event.controller.ts
@@ -15,23 +15,39 @@ import { EventService } from 'src/resource/event/event.service';
 import { GetUser } from 'src/decorators';
 import { CreateEventDTO, ReturnEventDTO } from 'src/resource/event/dto';
 import { EditEventDTO } from 'src/resource/event/dto/EditEvent.dto';
+import {
+    ApiBadRequestResponse,
+    ApiBody,
+    ApiCreatedResponse,
+    ApiNoContentResponse,
+    ApiNotFoundResponse,
+    ApiOkResponse,
+    ApiTags,
+} from '@nestjs/swagger';
 
 @UseGuards(JwtGuard)
+@ApiTags('Events')
 @Controller('events')
 export class EventController {
     constructor(private eventService: EventService) {}
 
     @Get()
+    @ApiOkResponse({ type: [ReturnEventDTO] })
     getUserEvents(@GetUser('id') userId: number): Promise<ReturnEventDTO[]> {
         return this.eventService.getEventsByUserId(userId);
     }
 
     @Get(':id')
+    @ApiOkResponse({ type: ReturnEventDTO })
+    @ApiNotFoundResponse({ description: 'Event not found' })
     getEventById(@Param('id') eventId: number): Promise<ReturnEventDTO> {
         return this.eventService.getEventById(eventId);
     }
 
     @Post()
+    @ApiCreatedResponse({ type: ReturnEventDTO })
+    @ApiBadRequestResponse({ description: 'Invalid body' })
+    @ApiBody({ type: CreateEventDTO })
     createEventByCurrentUser(
         @GetUser('id') userId: number,
         @Body() eventDto: CreateEventDTO,
@@ -40,6 +56,10 @@ export class EventController {
     }
 
     @Patch(':id')
+    @ApiOkResponse({ type: ReturnEventDTO })
+    @ApiBadRequestResponse({ description: 'Invalid body' })
+    @ApiNotFoundResponse({ description: "Event doesn't exist" })
+    @ApiBody({ type: EditEventDTO })
     editEvent(
         @Param('id') eventId: number,
         @Body() editEventDto: EditEventDTO,
@@ -48,6 +68,7 @@ export class EventController {
     }
 
     @HttpCode(HttpStatus.NO_CONTENT)
+    @ApiNoContentResponse()
     @Delete(':id')
     deleteEvent(@Param('id') eventId: number): Promise<void> {
         return this.eventService.removeEventById(eventId);

--- a/src/resource/notes/dto/editNote.dto.ts
+++ b/src/resource/notes/dto/editNote.dto.ts
@@ -1,23 +1,29 @@
 import { IsOptional, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class editNoteDTO {
     id: number;
 
     @IsString()
     @IsOptional()
+    @ApiProperty({ required: false })
     title?: string;
 
     @IsString()
     @IsOptional()
+    @ApiProperty({ required: false })
     body?: string;
 
     @IsString()
     @IsOptional()
+    @ApiProperty({ required: false })
     createdAt?: Date;
 
     @IsOptional()
+    @ApiProperty({ required: false })
     icon?: string;
 
     @IsOptional()
+    @ApiProperty({ required: false })
     color?: string;
 }

--- a/src/resource/notes/dto/notes.dto.ts
+++ b/src/resource/notes/dto/notes.dto.ts
@@ -1,21 +1,28 @@
 import { IsOptional, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class NoteDTO {
+    @ApiProperty()
     id: number;
 
     @IsString()
+    @ApiProperty()
     title: string;
 
     @IsString()
+    @ApiProperty()
     body: string;
 
     @IsString()
     @IsOptional()
+    @ApiProperty({ required: false })
     createdAt?: Date;
 
     @IsOptional()
+    @ApiProperty({ required: false })
     icon?: string;
 
     @IsOptional()
+    @ApiProperty({ required: false })
     color?: string;
 }

--- a/src/resource/notes/notes.controller.ts
+++ b/src/resource/notes/notes.controller.ts
@@ -1,20 +1,21 @@
 import {
+    Body,
     Controller,
     Get,
-    Post,
-    Body,
-    Patch,
     Param,
+    Patch,
+    Post,
     UseGuards,
 } from '@nestjs/common';
 import { NoteService } from './notes.service';
-import { NoteDTO } from './dto';
+import { editNoteDTO, NoteDTO } from './dto';
 import { JwtGuard } from '../../auth/guard';
-import { editNoteDTO } from './dto';
 import { GetUser } from '../../decorators';
 import { UserEntity } from 'src/database/entities/user.entity';
+import { ApiTags } from '@nestjs/swagger';
 
 @UseGuards(JwtGuard)
+@ApiTags('Notes')
 @Controller('notes')
 export class NoteController {
     constructor(private notesService: NoteService) {}

--- a/src/resource/notes/notes.controller.ts
+++ b/src/resource/notes/notes.controller.ts
@@ -12,15 +12,12 @@ import { editNoteDTO, NoteDTO } from './dto';
 import { JwtGuard } from '../../auth/guard';
 import { GetUser } from '../../decorators';
 import { UserEntity } from 'src/database/entities/user.entity';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import {
-    ApiBadRequestResponse,
-    ApiBearerAuth,
-    ApiBody,
-    ApiCreatedResponse,
-    ApiNotFoundResponse,
-    ApiOkResponse,
-    ApiTags,
-} from '@nestjs/swagger';
+    AddNoteApi,
+    EditNoteByIdApi,
+    FetchUserNotesApi,
+} from '../../decorators/OpenAPI/notes.decorators';
 
 @UseGuards(JwtGuard)
 @ApiTags('Notes')
@@ -30,24 +27,19 @@ export class NoteController {
     constructor(private notesService: NoteService) {}
 
     @Get()
-    @ApiOkResponse({ type: [NoteDTO] })
+    @FetchUserNotesApi()
     fetchUserNotes(@GetUser() user: UserEntity) {
         return this.notesService.fetchUserNotes(user);
     }
 
     @Post(':id')
-    @ApiCreatedResponse({ type: NoteDTO })
-    @ApiBadRequestResponse({ description: 'Invalid body' })
-    @ApiNotFoundResponse({ description: 'User not found' })
-    @ApiBody({ type: NoteDTO })
+    @AddNoteApi()
     addNote(@GetUser() user: UserEntity, @Body() noteDto: NoteDTO) {
         return this.notesService.addNote(user, noteDto);
     }
 
     @Patch(':id')
-    @ApiOkResponse()
-    @ApiBadRequestResponse({ description: 'Invalid body' })
-    @ApiBody({ type: editNoteDTO })
+    @EditNoteByIdApi()
     editNoteById(@Param('id') id: number, @Body() noteDto: editNoteDTO) {
         return this.notesService.editNoteById(id, noteDto);
     }

--- a/src/resource/notes/notes.controller.ts
+++ b/src/resource/notes/notes.controller.ts
@@ -12,25 +12,42 @@ import { editNoteDTO, NoteDTO } from './dto';
 import { JwtGuard } from '../../auth/guard';
 import { GetUser } from '../../decorators';
 import { UserEntity } from 'src/database/entities/user.entity';
-import { ApiTags } from '@nestjs/swagger';
+import {
+    ApiBadRequestResponse,
+    ApiBearerAuth,
+    ApiBody,
+    ApiCreatedResponse,
+    ApiNotFoundResponse,
+    ApiOkResponse,
+    ApiTags,
+} from '@nestjs/swagger';
 
 @UseGuards(JwtGuard)
 @ApiTags('Notes')
+@ApiBearerAuth()
 @Controller('notes')
 export class NoteController {
     constructor(private notesService: NoteService) {}
 
     @Get()
+    @ApiOkResponse({ type: [NoteDTO] })
     fetchUserNotes(@GetUser() user: UserEntity) {
         return this.notesService.fetchUserNotes(user);
     }
 
     @Post(':id')
+    @ApiCreatedResponse({ type: NoteDTO })
+    @ApiBadRequestResponse({ description: 'Invalid body' })
+    @ApiNotFoundResponse({ description: 'User not found' })
+    @ApiBody({ type: NoteDTO })
     addNote(@GetUser() user: UserEntity, @Body() noteDto: NoteDTO) {
         return this.notesService.addNote(user, noteDto);
     }
 
     @Patch(':id')
+    @ApiOkResponse()
+    @ApiBadRequestResponse({ description: 'Invalid body' })
+    @ApiBody({ type: editNoteDTO })
     editNoteById(@Param('id') id: number, @Body() noteDto: editNoteDTO) {
         return this.notesService.editNoteById(id, noteDto);
     }

--- a/src/resource/search/dto/SearchResult.dto.ts
+++ b/src/resource/search/dto/SearchResult.dto.ts
@@ -1,12 +1,22 @@
-import { ReturnEventDTO } from "src/resource/event/dto";
-import { NoteDTO } from "src/resource/notes/dto";
-import { ReturnTaskDTO } from "src/resource/task/dto";
+import { ReturnEventDTO } from 'src/resource/event/dto';
+import { NoteDTO } from 'src/resource/notes/dto';
+import { ReturnTaskDTO } from 'src/resource/task/dto';
+import { ApiProperty } from '@nestjs/swagger';
 
 enum ResourceType {
-    NOTES = "notes",
-    TASKS = "tasks",
-    EVENTS = "events"
+    NOTES = 'notes',
+    TASKS = 'tasks',
+    EVENTS = 'events',
 }
 
 type ReturnDTO = NoteDTO | ReturnTaskDTO | ReturnEventDTO;
 export type SearchResult = Record<ResourceType, ReturnDTO[]>;
+
+export class SearchResultDto {
+    @ApiProperty()
+    notes: NoteDTO[];
+    @ApiProperty()
+    tasks: ReturnTaskDTO[];
+    @ApiProperty()
+    events: ReturnEventDTO[];
+}

--- a/src/resource/search/search.controller.ts
+++ b/src/resource/search/search.controller.ts
@@ -3,30 +3,36 @@ import { SearchService } from './search.service';
 import { JwtGuard } from '../../auth/guard';
 import { GetUser } from '../../decorators';
 import { UserEntity } from 'src/database/entities/user.entity';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { SearchResultDto } from './dto';
 
 @UseGuards(JwtGuard)
 @ApiTags('Search')
+@ApiBearerAuth()
 @Controller('search')
 export class SearchController {
     constructor(private searchService: SearchService) {}
 
     @Get('/all/:search')
+    @ApiOkResponse({ type: SearchResultDto })
     searchAll(@GetUser() user: UserEntity, @Param('search') search: string) {
         return this.searchService.fetchAllBySearch(user, search);
     }
 
     @Get('/notes/:search')
+    @ApiOkResponse({ type: SearchResultDto })
     searchNotes(@GetUser() user: UserEntity, @Param('search') search: string) {
         return this.searchService.fetchNotesBySearch(user, search);
     }
 
     @Get('/tasks/:search')
+    @ApiOkResponse({ type: SearchResultDto })
     searchTasks(@GetUser() user: UserEntity, @Param('search') search: string) {
         return this.searchService.fetchTasksBySearch(user, search);
     }
 
     @Get('/events/:search')
+    @ApiOkResponse({ type: SearchResultDto })
     searchEvents(@GetUser() user: UserEntity, @Param('search') search: string) {
         return this.searchService.fetchEventsBySearch(user, search);
     }

--- a/src/resource/search/search.controller.ts
+++ b/src/resource/search/search.controller.ts
@@ -3,8 +3,8 @@ import { SearchService } from './search.service';
 import { JwtGuard } from '../../auth/guard';
 import { GetUser } from '../../decorators';
 import { UserEntity } from 'src/database/entities/user.entity';
-import { ApiBearerAuth, ApiOkResponse, ApiTags } from '@nestjs/swagger';
-import { SearchResultDto } from './dto';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { SearchApi } from '../../decorators/OpenAPI/search.decorators';
 
 @UseGuards(JwtGuard)
 @ApiTags('Search')
@@ -14,26 +14,38 @@ export class SearchController {
     constructor(private searchService: SearchService) {}
 
     @Get('/all/:search')
-    @ApiOkResponse({ type: SearchResultDto })
-    searchAll(@GetUser() user: UserEntity, @Param('search') search: string) {
+    @SearchApi()
+    async searchAll(
+        @GetUser() user: UserEntity,
+        @Param('search') search: string,
+    ) {
         return this.searchService.fetchAllBySearch(user, search);
     }
 
     @Get('/notes/:search')
-    @ApiOkResponse({ type: SearchResultDto })
-    searchNotes(@GetUser() user: UserEntity, @Param('search') search: string) {
+    @SearchApi()
+    async searchNotes(
+        @GetUser() user: UserEntity,
+        @Param('search') search: string,
+    ) {
         return this.searchService.fetchNotesBySearch(user, search);
     }
 
     @Get('/tasks/:search')
-    @ApiOkResponse({ type: SearchResultDto })
-    searchTasks(@GetUser() user: UserEntity, @Param('search') search: string) {
+    @SearchApi()
+    async searchTasks(
+        @GetUser() user: UserEntity,
+        @Param('search') search: string,
+    ) {
         return this.searchService.fetchTasksBySearch(user, search);
     }
 
     @Get('/events/:search')
-    @ApiOkResponse({ type: SearchResultDto })
-    searchEvents(@GetUser() user: UserEntity, @Param('search') search: string) {
+    @SearchApi()
+    async searchEvents(
+        @GetUser() user: UserEntity,
+        @Param('search') search: string,
+    ) {
         return this.searchService.fetchEventsBySearch(user, search);
     }
 }

--- a/src/resource/search/search.controller.ts
+++ b/src/resource/search/search.controller.ts
@@ -1,15 +1,12 @@
-import {
-    Controller,
-    Get,
-    Param,
-    UseGuards,
-} from '@nestjs/common';
+import { Controller, Get, Param, UseGuards } from '@nestjs/common';
 import { SearchService } from './search.service';
 import { JwtGuard } from '../../auth/guard';
 import { GetUser } from '../../decorators';
 import { UserEntity } from 'src/database/entities/user.entity';
+import { ApiTags } from '@nestjs/swagger';
 
 @UseGuards(JwtGuard)
+@ApiTags('Search')
 @Controller('search')
 export class SearchController {
     constructor(private searchService: SearchService) {}

--- a/src/resource/search/search.module.ts
+++ b/src/resource/search/search.module.ts
@@ -7,10 +7,15 @@ import { TaskEntity } from '../../database/entities/task.entity';
 import { EventEntity } from '../../database/entities/event.entity';
 import { UserEntity } from '../../database/entities/user.entity';
 
-
-
 @Module({
-    imports: [TypeOrmModule.forFeature([NoteEntity, TaskEntity, EventEntity, UserEntity])],
+    imports: [
+        TypeOrmModule.forFeature([
+            NoteEntity,
+            TaskEntity,
+            EventEntity,
+            UserEntity,
+        ]),
+    ],
     controllers: [SearchController],
     providers: [SearchService],
 })

--- a/src/resource/search/search.service.ts
+++ b/src/resource/search/search.service.ts
@@ -1,13 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { SearchResult } from './dto';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
-import { ILike } from 'typeorm';
+import { ILike, Repository } from 'typeorm';
 import { NoteEntity } from 'src/database/entities/notes.entity';
 import { TaskEntity } from 'src/database/entities/task.entity';
 import { EventEntity } from 'src/database/entities/event.entity';
 import { UserEntity } from 'src/database/entities/user.entity';
-
 
 @Injectable()
 export class SearchService {
@@ -17,30 +15,36 @@ export class SearchService {
         @InjectRepository(TaskEntity)
         private taskRepository: Repository<TaskEntity>,
         @InjectRepository(EventEntity)
-        private eventRepository: Repository<EventEntity>
+        private eventRepository: Repository<EventEntity>,
     ) {}
 
     private initResultObject = {
         notes: [],
         tasks: [],
-        events: []
-    }
+        events: [],
+    };
 
-    async fetchAllBySearch(user: UserEntity, search: string): Promise<SearchResult> {
+    async fetchAllBySearch(
+        user: UserEntity,
+        search: string,
+    ): Promise<SearchResult> {
         const searchResult = {
             notes: await this.findNotesBySearch(user, search),
             tasks: await this.findTasksBySearch(user, search),
-            events: await this.findEventsBySearch(user, search)
+            events: await this.findEventsBySearch(user, search),
         };
         return searchResult;
     }
 
-    async fetchNotesBySearch(user: UserEntity, search: string): Promise<SearchResult> {
+    async fetchNotesBySearch(
+        user: UserEntity,
+        search: string,
+    ): Promise<SearchResult> {
         const foundNotes = await this.findNotesBySearch(user, search);
         const searchResult = {
             ...this.initResultObject,
             notes: [...foundNotes],
-        }
+        };
         return searchResult;
     }
 
@@ -49,7 +53,7 @@ export class SearchService {
         const searchResult = {
             ...this.initResultObject,
             tasks: [...foundTasks],
-        }
+        };
         return searchResult;
     }
 
@@ -58,7 +62,7 @@ export class SearchService {
         const searchResult = {
             ...this.initResultObject,
             events: [...foundEvents],
-        }
+        };
         return searchResult;
     }
 
@@ -68,13 +72,13 @@ export class SearchService {
             where: [
                 {
                     user: user,
-                    title: ILike(pattern)
+                    title: ILike(pattern),
                 },
                 {
                     user: user,
-                    body: ILike(pattern)
-                }
-            ]
+                    body: ILike(pattern),
+                },
+            ],
         });
     }
 
@@ -84,13 +88,13 @@ export class SearchService {
             where: [
                 {
                     user: user,
-                    name: ILike(pattern)
+                    name: ILike(pattern),
                 },
                 {
                     user: user,
-                    description: ILike(pattern)
-                }
-            ]
+                    description: ILike(pattern),
+                },
+            ],
         });
     }
 
@@ -100,13 +104,13 @@ export class SearchService {
             where: [
                 {
                     createdBy: createdBy,
-                    name: ILike(pattern)
+                    name: ILike(pattern),
                 },
                 {
                     createdBy: createdBy,
-                    description: ILike(pattern)
-                }
-            ]
+                    description: ILike(pattern),
+                },
+            ],
         });
     }
 }

--- a/src/resource/task/dto/CreateTask.dto.ts
+++ b/src/resource/task/dto/CreateTask.dto.ts
@@ -1,14 +1,18 @@
 import { IsBoolean, IsOptional, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateTaskDTO {
     @IsString()
+    @ApiProperty()
     name: string;
 
     @IsString()
     @IsOptional()
+    @ApiProperty({ required: false })
     description?: string;
 
     @IsOptional()
     @IsBoolean()
+    @ApiProperty({ required: false })
     isDone?: boolean;
 }

--- a/src/resource/task/dto/EditTask.dto.ts
+++ b/src/resource/task/dto/EditTask.dto.ts
@@ -1,18 +1,23 @@
-import { IsBoolean, IsOptional, IsString, IsNumber } from 'class-validator';
+import { IsBoolean, IsNumber, IsOptional, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class EditTaskDTO {
     @IsNumber()
+    @ApiProperty()
     id: number;
 
     @IsString()
     @IsOptional()
+    @ApiProperty({ required: false })
     name?: string;
 
     @IsString()
     @IsOptional()
+    @ApiProperty({ required: false })
     description?: string;
 
     @IsOptional()
     @IsBoolean()
+    @ApiProperty({ required: false })
     isDone?: boolean;
 }

--- a/src/resource/task/dto/ReturnTask.dto.ts
+++ b/src/resource/task/dto/ReturnTask.dto.ts
@@ -1,9 +1,15 @@
 import { UserEntity } from 'src/database/entities/user.entity';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class ReturnTaskDTO {
+    @ApiProperty()
     id: number;
+    @ApiProperty()
     name: string;
+    @ApiProperty()
     description: string;
+    @ApiProperty()
     isDone: boolean;
+    @ApiProperty({ type: () => UserEntity })
     user: UserEntity;
 }

--- a/src/resource/task/task.controller.ts
+++ b/src/resource/task/task.controller.ts
@@ -1,24 +1,26 @@
 import {
+    BadRequestException,
     Body,
     Controller,
+    Delete,
     Get,
     HttpCode,
+    NotFoundException,
     Param,
     ParseIntPipe,
     Patch,
-    UseGuards,
     Post,
-    Delete,
-    NotFoundException,
-    BadRequestException,
+    UseGuards,
 } from '@nestjs/common';
 import { GetUser } from 'src/decorators';
 import { JwtGuard } from 'src/auth/guard';
-import { EditTaskDTO, ReturnTaskDTO, CreateTaskDTO } from './dto';
+import { CreateTaskDTO, EditTaskDTO, ReturnTaskDTO } from './dto';
 import { TaskService } from './task.service';
 import { UserEntity } from 'src/database/entities/user.entity';
+import { ApiTags } from '@nestjs/swagger';
 
 @UseGuards(JwtGuard)
+@ApiTags('Tasks')
 @Controller('tasks')
 export class TaskController {
     constructor(private readonly taskService: TaskService) {}

--- a/src/resource/task/task.controller.ts
+++ b/src/resource/task/task.controller.ts
@@ -18,16 +18,14 @@ import { JwtGuard } from 'src/auth/guard';
 import { CreateTaskDTO, EditTaskDTO, ReturnTaskDTO } from './dto';
 import { TaskService } from './task.service';
 import { UserEntity } from 'src/database/entities/user.entity';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import {
-    ApiBadRequestResponse,
-    ApiBearerAuth,
-    ApiBody,
-    ApiCreatedResponse,
-    ApiNoContentResponse,
-    ApiNotFoundResponse,
-    ApiOkResponse,
-    ApiTags,
-} from '@nestjs/swagger';
+    AddTaskApi,
+    DeleteTaskApi,
+    EditTaskApi,
+    GetAllUserTasksApi,
+    GetUserTaskApi,
+} from '../../decorators/OpenAPI/task.decorators';
 
 @UseGuards(JwtGuard)
 @ApiTags('Tasks')
@@ -37,7 +35,7 @@ export class TaskController {
     constructor(private readonly taskService: TaskService) {}
 
     @Get('/user/all')
-    @ApiOkResponse({ type: [ReturnTaskDTO] })
+    @GetAllUserTasksApi()
     async getAllUserTasks(
         @GetUser() user: UserEntity,
     ): Promise<ReturnTaskDTO[]> {
@@ -45,8 +43,7 @@ export class TaskController {
     }
 
     @Get('/user/:id')
-    @ApiOkResponse({ type: ReturnTaskDTO })
-    @ApiNotFoundResponse({ description: 'Task not found' })
+    @GetUserTaskApi()
     async getUserTask(
         @GetUser() user: UserEntity,
         @Param('id', ParseIntPipe) taskId: number,
@@ -60,9 +57,7 @@ export class TaskController {
     }
 
     @Post()
-    @ApiCreatedResponse({ type: ReturnTaskDTO })
-    @ApiBadRequestResponse({ description: 'Invalid body' })
-    @ApiBody({ type: CreateTaskDTO })
+    @AddTaskApi()
     async addTask(
         @GetUser() user: UserEntity,
         @Body() createTaskDTO: CreateTaskDTO,
@@ -71,12 +66,7 @@ export class TaskController {
     }
 
     @Patch(':id')
-    @ApiOkResponse({ type: ReturnTaskDTO })
-    @ApiBadRequestResponse({
-        description: 'Invalid body / ID is not valid in URL and body',
-    })
-    @ApiNotFoundResponse({ description: 'Task not found' })
-    @ApiBody({ type: EditTaskDTO })
+    @EditTaskApi()
     async editTask(
         @Param('id') id: number,
         @GetUser() user: UserEntity,
@@ -95,8 +85,7 @@ export class TaskController {
 
     @HttpCode(HttpStatus.NO_CONTENT)
     @Delete(':id')
-    @ApiNoContentResponse()
-    @ApiNotFoundResponse({ description: 'Task not found' })
+    @DeleteTaskApi()
     async deleteTask(
         @GetUser() user: UserEntity,
         @Param('id', ParseIntPipe) taskId: number,

--- a/src/resource/user/dto/EditUser.dto.ts
+++ b/src/resource/user/dto/EditUser.dto.ts
@@ -1,16 +1,20 @@
 import { IsEmail, IsEnum, IsOptional, IsString } from 'class-validator';
 import { UserRole } from '../../../types/enums';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class EditUserDTO {
     @IsString()
     @IsOptional()
+    @ApiProperty({ required: false })
     username?: string;
 
     @IsEmail()
     @IsOptional()
+    @ApiProperty({ required: false })
     email?: string;
 
     @IsEnum(UserRole)
     @IsOptional()
+    @ApiProperty({ required: false, enum: UserRole })
     role?: UserRole;
 }

--- a/src/resource/user/dto/ReturnUser.dto.ts
+++ b/src/resource/user/dto/ReturnUser.dto.ts
@@ -1,8 +1,13 @@
 import { UserRole } from 'src/types/enums';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class ReturnUserDTO {
+    @ApiProperty()
     id: number;
+    @ApiProperty()
     username: string;
+    @ApiProperty()
     email: string;
+    @ApiProperty({ enum: UserRole })
     role: UserRole;
 }

--- a/src/resource/user/user.controller.ts
+++ b/src/resource/user/user.controller.ts
@@ -14,24 +14,22 @@ import { EditUserDTO, ReturnUserDTO } from './dto';
 import { UserService } from './user.service';
 import { UserRoleGuard } from './guard';
 import { UserRole } from 'src/types/enums';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import {
-    ApiBadRequestResponse,
-    ApiBearerAuth,
-    ApiBody,
-    ApiNotFoundResponse,
-    ApiOkResponse,
-    ApiTags,
-} from '@nestjs/swagger';
+    EditMeApi,
+    GetMeApi,
+    GetUserByIdApi,
+} from '../../decorators/OpenAPI/user.decorators';
 
 @UseGuards(JwtGuard)
 @ApiTags('Users')
 @ApiBearerAuth()
 @Controller('users')
 export class UserController {
-    constructor(private readonly userservice: UserService) {}
+    constructor(private readonly userService: UserService) {}
 
     @Get('me')
-    @ApiOkResponse({ type: ReturnUserDTO })
+    @GetMeApi()
     getMe(@GetUser() user: UserEntity): ReturnUserDTO {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { hash, ...result } = user;
@@ -39,25 +37,21 @@ export class UserController {
     }
 
     @Patch('me')
-    @ApiOkResponse({ type: ReturnUserDTO })
-    @ApiBadRequestResponse({ description: 'Invalid body' })
-    @ApiNotFoundResponse({ description: 'User not found' })
-    @ApiBody({ type: EditUserDTO })
+    @EditMeApi()
     editMe(
         @GetUser('id') userId: number,
         @Body() editUserDto: EditUserDTO,
     ): Promise<ReturnUserDTO> {
-        return this.userservice.editMe(userId, editUserDto);
+        return this.userService.editMe(userId, editUserDto);
     }
 
     @ForRole(UserRole.ADMIN)
     @UseGuards(UserRoleGuard)
     @Get(':id')
-    @ApiOkResponse({ type: ReturnUserDTO })
-    @ApiNotFoundResponse({ description: 'User not found' })
+    @GetUserByIdApi()
     getUserById(
         @Param('id', ParseIntPipe) userId: number,
     ): Promise<ReturnUserDTO> {
-        return this.userservice.getUserById(userId);
+        return this.userService.getUserById(userId);
     }
 }

--- a/src/resource/user/user.controller.ts
+++ b/src/resource/user/user.controller.ts
@@ -14,8 +14,10 @@ import { EditUserDTO, ReturnUserDTO } from './dto';
 import { UserService } from './user.service';
 import { UserRoleGuard } from './guard';
 import { UserRole } from 'src/types/enums';
+import { ApiTags } from '@nestjs/swagger';
 
 @UseGuards(JwtGuard)
+@ApiTags('Users')
 @Controller('users')
 export class UserController {
     constructor(private readonly userservice: UserService) {}

--- a/src/resource/user/user.controller.ts
+++ b/src/resource/user/user.controller.ts
@@ -14,15 +14,24 @@ import { EditUserDTO, ReturnUserDTO } from './dto';
 import { UserService } from './user.service';
 import { UserRoleGuard } from './guard';
 import { UserRole } from 'src/types/enums';
-import { ApiTags } from '@nestjs/swagger';
+import {
+    ApiBadRequestResponse,
+    ApiBearerAuth,
+    ApiBody,
+    ApiNotFoundResponse,
+    ApiOkResponse,
+    ApiTags,
+} from '@nestjs/swagger';
 
 @UseGuards(JwtGuard)
 @ApiTags('Users')
+@ApiBearerAuth()
 @Controller('users')
 export class UserController {
     constructor(private readonly userservice: UserService) {}
 
     @Get('me')
+    @ApiOkResponse({ type: ReturnUserDTO })
     getMe(@GetUser() user: UserEntity): ReturnUserDTO {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { hash, ...result } = user;
@@ -30,6 +39,10 @@ export class UserController {
     }
 
     @Patch('me')
+    @ApiOkResponse({ type: ReturnUserDTO })
+    @ApiBadRequestResponse({ description: 'Invalid body' })
+    @ApiNotFoundResponse({ description: 'User not found' })
+    @ApiBody({ type: EditUserDTO })
     editMe(
         @GetUser('id') userId: number,
         @Body() editUserDto: EditUserDTO,
@@ -40,6 +53,8 @@ export class UserController {
     @ForRole(UserRole.ADMIN)
     @UseGuards(UserRoleGuard)
     @Get(':id')
+    @ApiOkResponse({ type: ReturnUserDTO })
+    @ApiNotFoundResponse({ description: 'User not found' })
     getUserById(
         @Param('id', ParseIntPipe) userId: number,
     ): Promise<ReturnUserDTO> {

--- a/src/resource/user/user.service.ts
+++ b/src/resource/user/user.service.ts
@@ -32,6 +32,7 @@ export class UserService {
 
     async getUserById(userId: number): Promise<ReturnUserDTO> {
         const user = await this.userRepository.findOneBy({ id: userId });
+        if (!user) throw new NotFoundException('User not found');
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { hash, ...result } = user;
         return result;


### PR DESCRIPTION
Added a Swagger/OpenAPI specification. All endpoints with descriptions, required parameters and bodies, response codes, etc. can be accessed at http://localhost:5000/swagger, or swagger-json for the json version. It also allows testing said endpoints in an interactive fashion, with support for Bearer token authentication.

Also reformatted the search module - Prettier did it by itself when I added the decorators